### PR TITLE
Don't allow user to create blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Discord community
     url: https://discord.apihacks.co


### PR DESCRIPTION
There is a  "OTHER" template, and the description of the template is: Use this for any other issues. PLEASE do not create blank issues

But, users can still open blank issues, this PR makes it so it doesn't allow them to.

